### PR TITLE
Add integration tests to the CD build process

### DIFF
--- a/cd_scripts/cd_functions.sh
+++ b/cd_scripts/cd_functions.sh
@@ -62,29 +62,29 @@ deploy_application(){
     fi
 }
 
-prepare_compatibility_tests(){
+prepare_web_tests(){
     if [ "$GITHUB_REPO_SLUG" == "DepartmentOfHealth-htbhf/htbhf-applicant-web-ui" ]; then
-        echo "Deploying $GITHUB_REPO_SLUG - using the version of the compatibility tests in $APP_VERSION"
-        export COMPATIBILITY_TESTS_DIR=${APP_PATH}
+        echo "Deploying $GITHUB_REPO_SLUG - using the version of the web tests in $APP_VERSION"
+        export WEB_TESTS_DIR=${APP_PATH}
     else
-        download_compatibility_tests
+        download_web_tests
     fi
 }
 
-download_compatibility_tests(){
-    # download the latest release of web ui (containing the compatibility tests) and extract to ${COMPATIBILITY_TESTS_DIR} (the directory will be deleted first)
-    check_variable_is_set COMPATIBILITY_TESTS_DIR
-    echo "Downloading latest release of compatibility tests"
-    rm -rf ${COMPATIBILITY_TESTS_DIR}
-    mkdir ${COMPATIBILITY_TESTS_DIR}
+download_web_tests(){
+    # download the latest release of web ui (containing the compatibility and integration tests) and extract to ${WEB_TESTS_DIR} (the directory will be deleted first)
+    check_variable_is_set WEB_TESTS_DIR
+    echo "Downloading latest release of web ui for tests"
+    rm -rf ${WEB_TESTS_DIR}
+    mkdir ${WEB_TESTS_DIR}
     curl -H "Authorization: token ${GH_WRITE_TOKEN}" -s https://api.github.com/repos/DepartmentOfHealth-htbhf/htbhf-applicant-web-ui/releases/latest \
         | grep zipball_url \
         | cut -d'"' -f4 \
-        | wget -qO compatibility-tests-tmp.zip -i -
-    unzip compatibility-tests-tmp.zip
-    mv -f DepartmentOfHealth-htbhf-htbhf-applicant-web-ui-*/* ${COMPATIBILITY_TESTS_DIR}
+        | wget -qO web-tests-tmp.zip -i -
+    unzip web-tests-tmp.zip
+    mv -f DepartmentOfHealth-htbhf-htbhf-applicant-web-ui-*/* ${WEB_TESTS_DIR}
     rm -rf DepartmentOfHealth-htbhf-htbhf-applicant-web-ui-*
-    rm compatibility-tests-tmp.zip
+    rm web-tests-tmp.zip
 }
 
 download_performance_tests(){

--- a/cd_scripts/publish_test_results.sh
+++ b/cd_scripts/publish_test_results.sh
@@ -7,6 +7,9 @@ git checkout gh-pages
 
 export TEST_RESULTS_DIR=${WORKING_DIR}/docs
 
+# copy Integration test report
+mv ${COMPATIBILITY_TESTS_DIR}/build/reports/integration-report.html ${TEST_RESULTS_DIR}
+
 # move compatibility test results to docs directory if we ran them
 if [ ! -z "${COMPATIBILITY_RESULTS_DIRECTORY}" ]; then
   # clear existing compatibility test results first

--- a/cd_scripts/publish_test_results.sh
+++ b/cd_scripts/publish_test_results.sh
@@ -8,7 +8,7 @@ git checkout gh-pages
 export TEST_RESULTS_DIR=${WORKING_DIR}/docs
 
 # copy Integration test report
-mv ${COMPATIBILITY_TESTS_DIR}/build/reports/integration-report.html ${TEST_RESULTS_DIR}
+mv ${WEB_TESTS_DIR}/build/reports/integration-report.html ${TEST_RESULTS_DIR}
 
 # move compatibility test results to docs directory if we ran them
 if [ ! -z "${COMPATIBILITY_RESULTS_DIRECTORY}" ]; then

--- a/cd_scripts/run.sh
+++ b/cd_scripts/run.sh
@@ -57,7 +57,7 @@ remove_route ${ROUTE} ${CF_PUBLIC_DOMAIN} ${HTBHF_APP}
 
 npm run test:integration:report
 
-check_exit_status $RESULT "Performance tests"
+check_exit_status $RESULT "Integration tests"
 
 if [ "$RUN_COMPATIBILITY_TESTS" == "true" ]; then
     echo "Creating temporary route for compatibility tests"

--- a/cd_scripts/run.sh
+++ b/cd_scripts/run.sh
@@ -11,7 +11,7 @@ export WORKING_DIR=$(pwd)
 export BIN_DIR=${WORKING_DIR}/bin
 export PERF_TESTS_DIR=${WORKING_DIR}/performance_tests
 export CD_SCRIPTS_DIR=${WORKING_DIR}/cd_scripts
-export COMPATIBILITY_TESTS_DIR=${WORKING_DIR}/compatibility_tests
+export WEB_TESTS_DIR=${WORKING_DIR}/web_tests
 
 source ${CD_SCRIPTS_DIR}/cd_functions.sh
 
@@ -42,11 +42,11 @@ create_random_route_name
 HTBHF_APP="help-to-buy-healthy-foods-${CF_SPACE}"
 cf map-route ${HTBHF_APP} ${CF_PUBLIC_DOMAIN} --hostname ${ROUTE}
 
-prepare_compatibility_tests
+prepare_web_tests
 
 echo "Running integration tests"
 export APP_BASE_URL="https://${ROUTE}.${CF_PUBLIC_DOMAIN}"
-cd ${COMPATIBILITY_TESTS_DIR}
+cd ${WEB_TESTS_DIR}
 npm install
 npm run test:integration
 
@@ -67,7 +67,7 @@ if [ "$RUN_COMPATIBILITY_TESTS" == "true" ]; then
 
     echo "Running compatibility tests"
     export APP_BASE_URL="https://${ROUTE}.${CF_PUBLIC_DOMAIN}"
-    cd ${COMPATIBILITY_TESTS_DIR}
+    cd ${WEB_TESTS_DIR}
     npm install
     npm run test:compatibility
     RESULT=$?
@@ -82,7 +82,7 @@ if [ "$RUN_COMPATIBILITY_TESTS" == "true" ]; then
     remove_route ${ROUTE} ${CF_PUBLIC_DOMAIN} ${HTBHF_APP}
 
     npm run test:compatibility:report
-    export COMPATIBILITY_RESULTS_DIRECTORY=${COMPATIBILITY_TESTS_DIR}/build/reports/compatibility-report
+    export COMPATIBILITY_RESULTS_DIRECTORY=${WEB_TESTS_DIR}/build/reports/compatibility-report
 
     check_exit_status $RESULT "Browser compatibility tests"
     cd ${WORKING_DIR}


### PR DESCRIPTION
 - Add integration tests to the start of every integration test build
 - Always download the web-ui because at least one set of tests will always be run
 - Rename compatibility test variables names to web test as it now applies to both compatibility tests and integration tests.
 - Add the integration test report to git hub pages